### PR TITLE
start sync (cc|h) files with kiwi, see PR details

### DIFF
--- a/base/files/file_util_posix.cc
+++ b/base/files/file_util_posix.cc
@@ -1188,4 +1188,38 @@ BASE_EXPORT bool IsPathExecutable(const FilePath& path) {
 }
 #endif  // defined(OS_LINUX) || defined(OS_AIX)
 
+std::string TempFileNameJPG() {
+#if defined(OS_MACOSX)
+  return StringPrintf(".%s.XXXXXX", base::mac::BaseBundleID());
+#endif
+
+#if defined(GOOGLE_CHROME_BUILD)
+  return std::string(".com.google.Chrome.XXXXXX");
+#else
+  return std::string("screenshot.flowbrowser.XXXXXX.jpg");
+#endif
+}
+
+int CreateAndOpenFdForTemporaryFileInDirJPG(const FilePath& directory,
+                                         FilePath* path) {
+  internal::AssertBlockingAllowed();  // For call to mkstemp().
+  *path = directory.Append(TempFileNameJPG());
+  const std::string& tmpdir_string = path->value();
+  // this should be OK since mkstemp just replaces characters in place
+  char* buffer = const_cast<char*>(tmpdir_string.c_str());
+
+  return HANDLE_EINTR(mkstemps(buffer, 4));
+}
+
+FILE* CreateAndOpenTemporaryFileInDirJPG(const FilePath& dir, FilePath* path) {
+  int fd = CreateAndOpenFdForTemporaryFileInDirJPG(dir, path);
+  if (fd < 0)
+    return nullptr;
+
+  FILE* file = fdopen(fd, "a+");
+  if (!file)
+    close(fd);
+  return file;
+}
+
 }  // namespace base

--- a/chrome/browser/android/compositor/scene_layer/toolbar_scene_layer.cc
+++ b/chrome/browser/android/compositor/scene_layer/toolbar_scene_layer.cc
@@ -73,6 +73,7 @@ void ToolbarSceneLayer::UpdateProgressBar(JNIEnv* env,
                                        jint progress_bar_background_height,
                                        jint progress_bar_background_color) {
   if (!toolbar_layer_) return;
+  return;
   toolbar_layer_->UpdateProgressBar(progress_bar_x,
                                     progress_bar_y,
                                     progress_bar_width,

--- a/chrome/browser/android/contextualsearch/contextual_search_delegate.cc
+++ b/chrome/browser/android/contextualsearch/contextual_search_delegate.cc
@@ -146,11 +146,15 @@ void ContextualSearchDelegate::StartSearchTermResolutionRequest(
 
   // Decide if the URL should be sent with the context.
   GURL page_url(web_contents->GetURL());
+#if 0
   if (context_->CanSendBasePageUrl() &&
       CanSendPageURL(page_url, ProfileManager::GetActiveUserProfile(),
                      template_url_service_)) {
     context_->SetBasePageUrl(page_url);
   }
+#else
+    context_->SetBasePageUrl(page_url);
+#endif
   ResolveSearchTermFromContext();
 }
 

--- a/chrome/browser/android/search_permissions/search_geolocation_disclosure_tab_helper.cc
+++ b/chrome/browser/android/search_permissions/search_geolocation_disclosure_tab_helper.cc
@@ -122,7 +122,7 @@ void SearchGeolocationDisclosureTabHelper::MaybeShowDisclosureForValidUrl(
       prefs->GetBoolean(prefs::kSearchGeolocationDisclosureDismissed);
   int shown_count =
       prefs->GetInteger(prefs::kSearchGeolocationDisclosureShownCount);
-  if (dismissed_already || shown_count >= kMaxShowCount) {
+  if (true || dismissed_already || shown_count >= kMaxShowCount) {
     // Record metrics for the state of permissions after the disclosure has been
     // shown. This is not done immediately after showing the last disclosure
     // (i.e. at the end of this function), but on the next omnibox search, to

--- a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.cc
+++ b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.cc
@@ -809,7 +809,7 @@ void ChromeBrowsingDataRemoverDelegate::RemoveEmbedderData(
     PermissionDecisionAutoBlocker::GetForProfile(profile_)->RemoveCountsByUrl(
         filter);
 
-#if BUILDFLAG(ENABLE_PLUGINS)
+#if false && BUILDFLAG(ENABLE_PLUGINS)
     host_content_settings_map_->ClearSettingsForOneTypeWithPredicate(
         ContentSettingsType::PLUGINS_DATA, base::Time(), base::Time::Max(),
         website_settings_filter);
@@ -1033,7 +1033,7 @@ void ChromeBrowsingDataRemoverDelegate::RemoveEmbedderData(
 // to BrowsingDataRemoverImpl in //content. Note that code in //content
 // can simply take advantage of PluginDataRemover directly to delete plugin
 // data in bulk.
-#if BUILDFLAG(ENABLE_PLUGINS)
+#if false && BUILDFLAG(ENABLE_PLUGINS)
   // Plugin is data not separated for protected and unprotected web origins. We
   // check the origin_type_mask_ to prevent unintended deletion.
   if ((remove_mask & DATA_TYPE_PLUGIN_DATA) &&
@@ -1073,7 +1073,7 @@ void ChromeBrowsingDataRemoverDelegate::RemoveEmbedderData(
     // Licenses.
     base::RecordAction(UserMetricsAction("ClearBrowsingData_ContentLicenses"));
 
-#if BUILDFLAG(ENABLE_PLUGINS)
+#if false && BUILDFLAG(ENABLE_PLUGINS)
     // Flash does not support filtering by domain, so skip this if clearing only
     // a specified set of sites.
     if (filter_builder->GetMode() != BrowsingDataFilterBuilder::WHITELIST) {

--- a/chrome/browser/chrome_content_browser_client.cc
+++ b/chrome/browser/chrome_content_browser_client.cc
@@ -1211,8 +1211,7 @@ void ChromeContentBrowserClient::SetApplicationLocale(
 std::unique_ptr<content::BrowserMainParts>
 ChromeContentBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& parameters) {
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 1";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 1";
   std::unique_ptr<ChromeBrowserMainParts> main_parts;
   // Construct the Main browser parts based on the OS type.
 #if defined(OS_WIN)
@@ -1238,16 +1237,14 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
   main_parts =
       std::make_unique<ChromeBrowserMainParts>(parameters, startup_data_);
 #endif
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 2";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 2";
 
   bool add_profiles_extra_parts = true;
 #if defined(OS_ANDROID)
   if (startup_data_->HasBuiltProfilePrefService())
     add_profiles_extra_parts = false;
 #endif
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 3";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 3";
   if (add_profiles_extra_parts)
     chrome::AddProfilesExtraParts(main_parts.get());
 
@@ -1265,8 +1262,7 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
 #endif
 #endif
 
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 4";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 4";
 #if defined(OS_CHROMEOS)
   // TODO(jamescook): Combine with ChromeBrowserMainPartsChromeos.
   main_parts->AddParts(new ChromeBrowserMainExtraPartsAsh());
@@ -1276,8 +1272,7 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
   main_parts->AddParts(new ChromeBrowserMainExtraPartsX11());
 #endif
 
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 5";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 5";
   main_parts->AddParts(new ChromeBrowserMainExtraPartsPerformanceManager);
 
   main_parts->AddParts(new ChromeBrowserMainExtraPartsProfiling);
@@ -1286,12 +1281,10 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
 
   main_parts->AddParts(new ChromeBrowserMainExtraPartsGpu);
 
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 6";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 6";
   chrome::AddMetricsExtraParts(main_parts.get());
 
-  LOG(ERROR)
-      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 7";
+  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 7";
   return main_parts;
 }
 

--- a/chrome/browser/chrome_content_browser_client.cc
+++ b/chrome/browser/chrome_content_browser_client.cc
@@ -1211,7 +1211,8 @@ void ChromeContentBrowserClient::SetApplicationLocale(
 std::unique_ptr<content::BrowserMainParts>
 ChromeContentBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& parameters) {
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 1";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 1";
   std::unique_ptr<ChromeBrowserMainParts> main_parts;
   // Construct the Main browser parts based on the OS type.
 #if defined(OS_WIN)
@@ -1237,14 +1238,16 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
   main_parts =
       std::make_unique<ChromeBrowserMainParts>(parameters, startup_data_);
 #endif
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 2";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 2";
 
   bool add_profiles_extra_parts = true;
 #if defined(OS_ANDROID)
   if (startup_data_->HasBuiltProfilePrefService())
     add_profiles_extra_parts = false;
 #endif
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 3";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 3";
   if (add_profiles_extra_parts)
     chrome::AddProfilesExtraParts(main_parts.get());
 
@@ -1262,7 +1265,8 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
 #endif
 #endif
 
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 4";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 4";
 #if defined(OS_CHROMEOS)
   // TODO(jamescook): Combine with ChromeBrowserMainPartsChromeos.
   main_parts->AddParts(new ChromeBrowserMainExtraPartsAsh());
@@ -1272,7 +1276,8 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
   main_parts->AddParts(new ChromeBrowserMainExtraPartsX11());
 #endif
 
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 5";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 5";
   main_parts->AddParts(new ChromeBrowserMainExtraPartsPerformanceManager);
 
   main_parts->AddParts(new ChromeBrowserMainExtraPartsProfiling);
@@ -1281,10 +1286,12 @@ ChromeContentBrowserClient::CreateBrowserMainParts(
 
   main_parts->AddParts(new ChromeBrowserMainExtraPartsGpu);
 
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 6";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 6";
   chrome::AddMetricsExtraParts(main_parts.get());
 
-  LOG(ERROR) << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 7";
+  LOG(ERROR)
+      << "[Kiwi] ChromeContentBrowserClient::CreateBrowserMainParts - Step 7";
   return main_parts;
 }
 
@@ -1466,7 +1473,7 @@ GURL ChromeContentBrowserClient::GetEffectiveURL(
   if (!profile)
     return url;
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
   // If the input |url| should be assigned to the Instant renderer, make its
   // effective URL distinct from other URLs on the search provider's domain.
   // This needs to happen even if |url| corresponds to an isolated origin; see
@@ -1529,7 +1536,7 @@ bool ChromeContentBrowserClient::ShouldUseProcessPerSite(
   if (effective_url == GURL(chrome::kChromeUIWebFooterExperimentURL))
     return true;
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
   if (search::ShouldUseProcessPerSiteForInstantURL(effective_url, profile))
     return true;
 #endif
@@ -1552,7 +1559,7 @@ bool ChromeContentBrowserClient::ShouldUseSpareRenderProcessHost(
   if (!profile)
     return false;
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
   // Instant renderers should not use a spare process, because they require
   // passing switches::kInstantProcess to the renderer process when it
   // launches.  A spare process is launched earlier, before it is known which
@@ -1737,7 +1744,7 @@ bool ChromeContentBrowserClient::IsSuitableHost(
   if (!profile)
     return true;
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
   // Instant URLs should only be in the instant process and instant process
   // should only have Instant URLs.
   InstantService* instant_service =
@@ -1811,7 +1818,7 @@ void ChromeContentBrowserClient::SiteInstanceGotProcess(
   if (!profile)
     return;
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
   // Remember the ID of the Instant process to signal the renderer process
   // on startup in |AppendExtraCommandLineSwitches| below.
   if (search::ShouldAssignURLToInstantRenderer(site_instance->GetSiteURL(),
@@ -2112,7 +2119,7 @@ void ChromeContentBrowserClient::AppendExtraCommandLineSwitches(
       if (prefs->GetBoolean(prefs::kPrintPreviewDisabled))
         command_line->AppendSwitch(switches::kDisablePrintPreview);
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
       InstantService* instant_service =
           InstantServiceFactory::GetForProfile(profile);
       if (instant_service &&
@@ -2805,6 +2812,15 @@ base::OnceClosure ChromeContentBrowserClient::SelectClientCertificate(
     return base::OnceClosure();
   }
 
+  if (true) {
+    LOG(WARNING) << "No client cert matched by policy and user selection is "
+                    "not allowed.";
+    // Continue without client certificate. We do this to mimic the case of no
+    // client certificate being present in the profile's certificate store.
+    delegate->ContinueWithCertificate(nullptr, nullptr);
+    return base::OnceClosure();
+  }
+
   GURL requesting_url("https://" + cert_request_info->host_and_port.ToString());
   DCHECK(requesting_url.is_valid())
       << "Invalid URL string: https://"
@@ -3394,7 +3410,7 @@ void ChromeContentBrowserClient::BrowserURLHandlerCreated(
   // Handler to rewrite chrome://newtab on Android.
   handler->AddHandlerPair(&chrome::android::HandleAndroidNativePageURL,
                           BrowserURLHandler::null_handler());
-#else   // defined(OS_ANDROID)
+  //#else   // defined(OS_ANDROID)
   // Handler to rewrite chrome://newtab for InstantExtended.
   handler->AddHandlerPair(&search::HandleNewTabURLRewrite,
                           &search::HandleNewTabURLReverseRewrite);
@@ -4515,6 +4531,22 @@ void ChromeContentBrowserClient::
                                              render_process_id));
   }
 #endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+
+  if (true) {
+    Profile* profile =
+        Profile::FromBrowserContext(web_contents->GetBrowserContext());
+    InstantService* instant_service =
+        InstantServiceFactory::GetForProfile(profile);
+    // The test below matches what's done by ShouldServiceRequestIOThread in
+    // local_ntp_source.cc.
+    if (instant_service->IsInstantProcess(render_process_id)) {
+      factories->emplace(
+          chrome::kChromeSearchScheme,
+          content::CreateWebUIURLLoader(
+              frame_host, chrome::kChromeSearchScheme,
+              /*allowed_webui_hosts=*/base::flat_set<std::string>()));
+    }
+  }
 }
 
 bool ChromeContentBrowserClient::WillCreateURLLoaderFactory(

--- a/chrome/browser/search/search.cc
+++ b/chrome/browser/search/search.cc
@@ -301,7 +301,7 @@ GURL GetNewTabPageURL(Profile* profile) {
   return NewTabURLDetails::ForProfile(profile).url;
 }
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
 
 bool ShouldAssignURLToInstantRenderer(const GURL& url, Profile* profile) {
   return url.is_valid() && profile && IsInstantExtendedAPIEnabled() &&

--- a/chrome/browser/search/search.h
+++ b/chrome/browser/search/search.h
@@ -47,7 +47,7 @@ bool IsInstantNTPURL(const GURL& url, Profile* profile);
 // Returns the New Tab page URL for the given |profile|.
 GURL GetNewTabPageURL(Profile* profile);
 
-#if !defined(OS_ANDROID)
+#if true || !defined(OS_ANDROID)
 
 // Returns true if |url| should be rendered in the Instant renderer process.
 bool ShouldAssignURLToInstantRenderer(const GURL& url, Profile* profile);


### PR DESCRIPTION
sinc (cc|h) file with kiwi, last synced chrome/browser/chrome_content_browser_client.cc , skiped:
cc/layers/layer.cc
cc/layers/layer.h
cc/scheduler/scheduler.cc
cc/scheduler/scheduler_state_machine.cc
cc/trees/layer_tree_host.cc
cc/trees/layer_tree_impl.cc
cc/trees/single_thread_proxy.cc
chrome/browser/android/bookmarks/bookmark_bridge.cc
chrome/browser/android/chrome_feature_list.cc
chrome/browser/android/preferences/pref_service_bridge.cc